### PR TITLE
chore: 配置.gitignore忽略.obsidian目录除app.json外

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ pnpm-debug.log*
 # Editor directories and files
 .idea
 .vscode
+.obsidian/*
+!.obsidian/app.json
 *.suo
 *.ntvs*
 *.njsproj

--- a/.obsidian/app.json
+++ b/.obsidian/app.json
@@ -1,0 +1,5 @@
+{
+  "attachmentFolderPath": "docs/public/images/doc",
+  "useMarkdownLinks": true,
+  "newLinkFormat": "relative"
+}


### PR DESCRIPTION
新增.gitignore规则，忽略.obsidian目录下所有文件，
但保留app.json文件。方便管理Obsidian配置文件，避免
无关文件被提交。新增app.json配置附件路径和链接格式。