### PR TITLE
docs: 删除文档中无用的 order 字段，简化配置

### DIFF
--- a/docs/zhHans/obsidian-yearly-glance/advanced-usage/index.md
+++ b/docs/zhHans/obsidian-yearly-glance/advanced-usage/index.md
@@ -1,5 +1,4 @@
 ---
 title: 高级使用
 draft: true
-order: 3
 ---

--- a/docs/zhHans/obsidian-yearly-glance/guide/index.md
+++ b/docs/zhHans/obsidian-yearly-glance/guide/index.md
@@ -1,6 +1,5 @@
 ---
 title: 指南
-order: 1
 draft: false
 ---
 


### PR DESCRIPTION
移除高级使用和指南页面的 order 字段，避免排序冲突，
提升文档管理的简洁性和维护效率。