### PR TITLE
feat(docs): 添加“Obsidian 文件夹打开器”文档与导航项

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -25,7 +25,6 @@ console.log('VITE_BASE_URL:', VITE_BASE_URL)
 
 import { existsSync } from 'fs';
 import { join } from 'path';
-import { text } from 'stream/consumers';
 
 const defaultLocale: string = 'zhHans';
 const supportLocales: string[] = [defaultLocale, 'en'];

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -25,6 +25,7 @@ console.log('VITE_BASE_URL:', VITE_BASE_URL)
 
 import { existsSync } from 'fs';
 import { join } from 'path';
+import { text } from 'stream/consumers';
 
 const defaultLocale: string = 'zhHans';
 const supportLocales: string[] = [defaultLocale, 'en'];
@@ -61,7 +62,8 @@ const vitePressSidebarConfig: VitePressSidebarOptions[] = [
       'obsidian-ace-code-editor',
       'obsidian-custom-icons', 
       'obsidian-ravenhogwarts-toolkit',
-      'obsidian-yearly-glance'
+      'obsidian-yearly-glance',
+      'open-folder-with-obsidian'
     ];
     
     // 插件自定义配置
@@ -129,6 +131,11 @@ const vitePressI18nConfig: VitePressI18nOptions = {
             { text: 'RavenHogwarts Toolkit(OTK)', link: '/obsidian-ravenhogwarts-toolkit/' },
           ]
         },
+        { text: '实用小工具',
+          items: [
+            { text: 'Open Folder with Obsidian', link: '/open-folder-with-obsidian/' },
+          ]
+        },
         { text: `VitePress ${pkg.version}`, link: 'https://vitepress.dev/zh/', noIcon: true },
       ],
       search: {
@@ -190,6 +197,11 @@ const vitePressI18nConfig: VitePressI18nOptions = {
             { text: 'Custom Icons', link: '/en/obsidian-custom-icons/' },
             { text: 'Yearly Glance', link: '/en/obsidian-yearly-glance/' },
             { text: 'RavenHogwarts Toolkit(OTK)', link: '/en/obsidian-ravenhogwarts-toolkit/' },
+          ]
+        },
+        { text: 'Utilities',
+          items: [
+            { text: 'Open Folder with Obsidian', link: '/en/open-folder-with-obsidian/' },
           ]
         },
         { text: `VitePress ${pkg.version}`, link: 'https://vitepress.dev/', noIcon: true },

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -49,6 +49,18 @@ hero:
           link: '/obsidian-custom-icons/'
         },
       ]
+    },
+    {
+      icon: 'Wrench',
+      title: 'Utilities',
+      items: [
+        {
+          icon: 'FolderOpen',
+          title: 'Obsidian Folder Opener',
+          description: 'Right-click to open folders as Obsidian vaults in Windows',
+          link: '/open-folder-with-obsidian/'
+        }
+      ]
     }
   ]
 </script>

--- a/docs/en/open-folder-with-obsidian/guide/index.md
+++ b/docs/en/open-folder-with-obsidian/guide/index.md
@@ -1,0 +1,4 @@
+---
+title: Guide
+draft: false
+---

--- a/docs/en/open-folder-with-obsidian/guide/principle.md
+++ b/docs/en/open-folder-with-obsidian/guide/principle.md
@@ -1,0 +1,79 @@
+---
+title: Operating Principle
+order: 4
+---
+
+# How It Works
+
+## How Obsidian Opens Vaults
+
+Obsidian's vault information is stored in the `%APPDATA%\obsidian\obsidian.json` file, and vaults marked as `"open": true` will be opened.
+
+- `path`: Complete path to the folder
+- `ts`: Timestamp (milliseconds), recording vault creation or last access time
+- `open`: Boolean value, marking whether it's the currently open vault
+
+```json
+{
+  "vaults": {
+    "1a2b3c4d5e6f7890": {
+      "path": "C:\\Users\\Username\\Documents\\MyNotes",
+      "ts": 1692000000000,
+      "open": true
+    },
+    "0987654321abcdef": {
+      "path": "C:\\Projects\\Documentation",
+      "ts": 1691000000000
+    }
+  }
+}
+```
+
+## Windows Registry Context Menu
+
+By modifying the registry to add "Open with Obsidian" option to folder context menus, there are two entry points:
+- **Folder right-click**: Right-click directly on a folder, calls the program and passes the folder path
+- **Inside folder right-click**: Right-click on empty space inside a folder, calls the program and passes the current directory path
+
+Registry locations:
+- `HKEY_CLASSES_ROOT\Directory\shell\OpenWithObsidian` - Folder right-click
+- `HKEY_CLASSES_ROOT\Directory\Background\shell\OpenWithObsidian` - Inside folder right-click
+
+## Installer Working Principle
+
+### 1. Detect Obsidian Path
+- Search for Obsidian installation path from registry uninstall information
+- Check common installation locations (Program Files, user directory, etc.)
+- If automatic detection fails, provide manual selection interface
+
+### 2. Copy Main Program
+Copy `open_folder_with_obsidian.exe` to the Obsidian installation directory
+
+### 3. Generate Registry File
+Create `.reg` file to configure context menu, including:
+- Menu item text and icon
+- Execute command and parameter format
+- Cleanup script for uninstallation
+
+### 4. Apply Registry Configuration
+Execute registry file with administrator privileges to complete context menu addition
+
+## Context Menu Execution Process
+
+### 1. Receive Folder Path
+
+Program starts and receives one parameter: the folder path to open
+
+### 2. Read Obsidian Configuration
+Read current vault configuration information from `%APPDATA%\obsidian\obsidian.json`
+
+### 3. Generate Vault Configuration
+- Generate unique vault ID for folder path (using first 16 characters of MD5 hash)
+- Create new vault configuration entry with path, timestamp, and open flag
+- Clear open flags of other vaults to ensure only the new vault is activated
+
+### 4. Update Configuration File
+Write modified configuration back to `obsidian.json` file
+
+### 5. Launch Obsidian
+Find and start Obsidian application, which will automatically read the configuration and open the vault marked as open

--- a/docs/en/open-folder-with-obsidian/guide/usage.md
+++ b/docs/en/open-folder-with-obsidian/guide/usage.md
@@ -1,0 +1,32 @@
+---
+title: Installation and Usage
+order: 1
+---
+
+# How to Download and Use
+
+## Download Pre-compiled Version
+
+1. Visit the [Releases page](https://github.com/RavenHogwarts/open-folder-with-obsidian/releases)
+2. Download the latest version of `obsidian-folder-opener.zip` and extract it
+3. Run the installer `obsidian_installer.exe` as administrator
+4. Follow the prompts to complete the installation
+
+## Usage
+
+After installation, you can use it in the following ways:
+
+### 1. Folder Right-click Menu
+- **Right-click** on any folder
+- Select "**Open with Obsidian**"
+
+### 2. Inside Folder Right-click Menu
+- **Right-click** on an empty area inside a folder
+- Select "**Open this folder in Obsidian**"
+
+## Uninstall
+
+To uninstall the right-click menu functionality:
+
+1. Double-click to run the `remove_obsidian_context_menu.reg` file
+2. Find the Obsidian installation directory and delete `open_folder_with_obsidian.exe` from the directory

--- a/docs/en/open-folder-with-obsidian/index.md
+++ b/docs/en/open-folder-with-obsidian/index.md
@@ -1,0 +1,7 @@
+# Open Folder With Obsidian
+
+::: info 简介
+一个 Windows 右键菜单工具，让您可以直接用 Obsidian 打开任意文件夹作为 vault 。
+
+**项目地址**：[GitHub - open-folder-with-obsidian](https://github.com/RavenHogWarts/open-folder-with-obsidian)
+:::

--- a/docs/zhHans/index.md
+++ b/docs/zhHans/index.md
@@ -48,6 +48,18 @@ hero:
           link: '/obsidian-custom-icons/'
         },
       ]
+    },
+    {
+      icon: 'Wrench',
+      title: '实用小工具',
+      items: [
+        {
+          icon: 'FolderOpen',
+          title: 'Obsidian 文件夹打开器',
+          description: 'Windows 中右键使用 Obsidian 将文件夹作为库打开',
+          link: '/open-folder-with-obsidian/'
+        }
+      ]
     }
   ]
 </script>

--- a/docs/zhHans/open-folder-with-obsidian/guide/index.md
+++ b/docs/zhHans/open-folder-with-obsidian/guide/index.md
@@ -1,0 +1,4 @@
+---
+title: 指南
+draft: false
+---

--- a/docs/zhHans/open-folder-with-obsidian/guide/principle.md
+++ b/docs/zhHans/open-folder-with-obsidian/guide/principle.md
@@ -1,0 +1,79 @@
+---
+title: 运行原理
+order: 4
+---
+
+# 如何运行生效的
+
+## obsidian 如何打开库
+
+Obsidian 的 vault 信息存储在 `%APPDATA%\obsidian\obsidian.json` 文件中，标记为 `"open": true` 的库将会被打开
+
+- `path`: 文件夹的完整路径
+- `ts`: 时间戳（毫秒），记录 vault 创建或最后访问时间
+- `open`: 布尔值，标记是否为当前打开的 vault
+
+```json
+{
+  "vaults": {
+    "1a2b3c4d5e6f7890": {
+      "path": "C:\\Users\\Username\\Documents\\MyNotes",
+      "ts": 1692000000000,
+      "open": true
+    },
+    "0987654321abcdef": {
+      "path": "C:\\Projects\\Documentation",
+      "ts": 1691000000000
+    }
+  }
+}
+```
+
+## Windows 注册右键菜单
+
+通过修改注册表在文件夹右键菜单中添加"Open with Obsidian"选项，共有两个入口：
+- **文件夹右键**：在文件夹上直接右键，调用程序并传递文件夹路径
+- **文件夹内右键**：在文件夹内空白处右键，调用程序并传递当前目录路径
+
+注册表位置：
+- `HKEY_CLASSES_ROOT\Directory\shell\OpenWithObsidian` - 文件夹右键
+- `HKEY_CLASSES_ROOT\Directory\Background\shell\OpenWithObsidian` - 文件夹内右键
+
+## 安装程序工作原理
+
+### 1. 检测 Obsidian 路径
+- 从注册表的卸载信息中查找 Obsidian 安装路径
+- 检查常见安装位置（Program Files、用户目录等）
+- 如果自动检测失败，提供手动选择界面
+
+### 2. 复制主程序
+将 `open_folder_with_obsidian.exe` 复制到 Obsidian 安装目录
+
+### 3. 生成注册表文件
+创建 `.reg` 文件配置右键菜单，包括：
+- 菜单项文本和图标
+- 执行命令和参数格式
+- 卸载用的清理脚本
+
+### 4. 应用注册表配置
+以管理员权限执行注册表文件，完成右键菜单的添加
+
+## 右键菜单运行过程
+
+### 1. 接收文件夹路径
+
+程序启动接收一个参数：要打开的文件夹路径
+
+### 2. 读取 Obsidian 配置
+从 `%APPDATA%\obsidian\obsidian.json` 读取当前的 vault 配置信息
+
+### 3. 生成 vault 配置
+- 为文件夹路径生成唯一的 vault ID（使用 MD5 哈希值前16位）
+- 创建新的 vault 配置项，包含路径、时间戳和 open 标记
+- 清除其他 vault 的 open 标记，确保只有新 vault 被激活
+
+### 4. 更新配置文件
+将修改后的配置写回 `obsidian.json` 文件
+
+### 5. 启动 Obsidian
+查找并启动 Obsidian 应用程序，Obsidian 会自动读取配置并打开标记为 open 的 vault

--- a/docs/zhHans/open-folder-with-obsidian/guide/usage.md
+++ b/docs/zhHans/open-folder-with-obsidian/guide/usage.md
@@ -1,0 +1,32 @@
+---
+title: 安装使用
+order: 1
+---
+
+# 如何下载使用
+
+## 下载预编译版本
+
+1. 访问 [Releases页面](https://github.com/RavenHogwarts/open-folder-with-obsidian/releases)
+2. 下载最新版本的 `obsidian-folder-opener.zip`, 并解压
+3. 以管理员身份运行安装程序 `obsidian_installer.exe`
+4. 按照提示完成安装
+
+## 使用方法
+
+安装完成后，您可以通过以下方式使用：
+
+### 1. 文件夹右键菜单
+- 在任意文件夹上**右键点击**
+- 选择"**Open with Obsidian**"
+
+### 2. 文件夹内右键菜单
+- 在文件夹内的**空白处右键点击**
+- 选择"**Open this folder in Obsidian**"
+
+## 卸载
+
+如需卸载右键菜单功能：
+
+1. 双击运行 `remove_obsidian_context_menu.reg` 文件
+2. 找到Obsidian安装目录，删除目录下的 `open_folder_with_obsidian.exe`

--- a/docs/zhHans/open-folder-with-obsidian/index.md
+++ b/docs/zhHans/open-folder-with-obsidian/index.md
@@ -1,0 +1,7 @@
+# Open Folder With Obsidian
+
+::: info 简介
+一个 Windows 右键菜单工具，让您可以直接用 Obsidian 打开任意文件夹作为 vault 。
+
+**项目地址**：[GitHub - open-folder-with-obsidian](https://github.com/RavenHogWarts/open-folder-with-obsidian)
+:::


### PR DESCRIPTION
新增英文与简体中文的文档页面，包含安装、使用、卸载和运行原理说明，
重点说明通过注册表添加文件夹右键与文件夹内右键两种入口的行为及安装器
如何检测 Obsidian 路径、复制主程序、生成并应用 .reg 配置来实现右键菜单。
在站点导航和配置中注册该工具，向导航栏添加“实用小工具 / Obsidian
Folder Opener”条目并更新中文对应项，确保中英文网站均可访问该指南。
还修复了 config 导入声明顺序以便注册新模块。